### PR TITLE
Provision a LEMP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## TODOs
 
 - Document a simple backup helper for Laravel
+- Document for the provision-lemp.sh script
 
 ## License (MIT)
 

--- a/scripts/mysql-setup.sh
+++ b/scripts/mysql-setup.sh
@@ -23,6 +23,7 @@ do
         F_MYSQL_VERSION="$VALUE"
     else
         echo "[error] Unrecognized option $NAME"
+        exit 1
     fi
 done
 

--- a/scripts/mysql-setup.sh
+++ b/scripts/mysql-setup.sh
@@ -1,16 +1,32 @@
 #!/usr/bin/env bash
 
+# ./mysql-setup.sh --version=8.0
+
 if [ "$USER" != 'root' ]; then
-    echo 'root privileges required. Please run this script as root.'
+    echo '[error] root privileges required. Please run this script as root.'
     exit 1
 fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-# TODO: Should be customizable.
-C_MYSQL_PASSWORD="secret"
+F_MYSQL_VERSION='8.0'
 
-debconf-set-selections <<< "mysql-server mysql-server/root_password password ${C_MYSQL_PASSWORD}"
-debconf-set-selections <<< "mysql-server mysql-server/root_password_again password ${C_MYSQL_PASSWORD}"
+# TODO: Should be customizable.
+F_MYSQL_PASSWORD="secret"
+
+for OPTION in "$@"
+do
+    NAME="$(cut -d'=' -f1 <<<"$OPTION")"
+    VALUE="$(cut -d'=' -f2 <<<"$OPTION")"
+
+    if [ "$NAME" = '--version' ]; then
+        F_MYSQL_VERSION="$VALUE"
+    else
+        echo "[error] Unrecognized option $NAME"
+    fi
+done
+
+debconf-set-selections <<< "mysql-server mysql-server/root_password password ${F_MYSQL_PASSWORD}"
+debconf-set-selections <<< "mysql-server mysql-server/root_password_again password ${F_MYSQL_PASSWORD}"
 
 apt-get -y install mysql-server

--- a/scripts/nginx-setup.sh
+++ b/scripts/nginx-setup.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 
+# ./nginx-setup.sh --user=forge
+
 if [ "$USER" != 'root' ]; then
-    echo 'root privileges required. Please run this script as root.'
+    echo '[error] root privileges required. Please run this script as root.'
     exit 1
 fi
 
-# TODO: Should be customizable.
-C_USERNAME="forge"
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
+F_USERNAME="forge"
+
+for OPTION in "$@"
+do
+    NAME="$(cut -d'=' -f1 <<<"$OPTION")"
+    VALUE="$(cut -d'=' -f2 <<<"$OPTION")"
+
+    if [ "$NAME" = '--user' ]; then
+        F_USERNAME="$VALUE"
+    else
+        echo "[error] Unrecognized option $NAME"
+    fi
+done
 
 apt-get install -y nginx
 
@@ -26,4 +42,4 @@ wget -O fastcgi-php.conf https://raw.githubusercontent.com/confetticode/forge-li
 mv fastcgi.conf /etc/nginx/extra/fastcgi.conf
 mv fastcgi-php.conf /etc/nginx/extra/fastcgi-php.conf
 
-sed -i "s/www-data/${C_USERNAME}/g" /etc/nginx/nginx.conf;
+sed -i "s/www-data/${F_USERNAME}/g" /etc/nginx/nginx.conf;

--- a/scripts/nginx-setup.sh
+++ b/scripts/nginx-setup.sh
@@ -21,6 +21,7 @@ do
         F_USERNAME="$VALUE"
     else
         echo "[error] Unrecognized option $NAME"
+        exit 1
     fi
 done
 
@@ -36,10 +37,12 @@ git clone https://github.com/h5bp/server-configs-nginx.git /etc/nginx
 
 mkdir -p /etc/nginx/extra
 
-wget -O fastcgi.conf https://raw.githubusercontent.com/confetticode/forge-like-setup/main/etc/fastcgi.conf
-wget -O fastcgi-php.conf https://raw.githubusercontent.com/confetticode/forge-like-setup/main/etc/fastcgi-php.conf
+wget -O fastcgi.conf https://raw.githubusercontent.com/confetticode/forge-like-setup/main/etc/fastcgi.conf --quiet
+wget -O fastcgi-php.conf https://raw.githubusercontent.com/confetticode/forge-like-setup/main/etc/fastcgi-php.conf --quiet
 
 mv fastcgi.conf /etc/nginx/extra/fastcgi.conf
 mv fastcgi-php.conf /etc/nginx/extra/fastcgi-php.conf
 
 sed -i "s/www-data/${F_USERNAME}/g" /etc/nginx/nginx.conf;
+
+systemctl restart nginx

--- a/scripts/php-setup.sh
+++ b/scripts/php-setup.sh
@@ -23,6 +23,7 @@ do
         F_PHP_VERSION="$VALUE"
     else
         echo "[error] Unrecognized option $NAME"
+        exit 1
     fi
 done
 
@@ -46,8 +47,12 @@ apt-get install -y \
 
 php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
 
+# user = forge
+# group = forge
 sed -i "s/www-data/${F_USERNAME}/g" "/etc/php/${F_PHP_VERSION}/fpm/pool.d/www.conf";
-#sed -i "s/www-data/[www]/g" "/etc/php/[PHP ${F_PHP_VERSION}]/fpm/pool.d/www.conf";
+
+# Change the pool name
+sed -i "s/\[www\]/\[PHP $F_PHP_VERSION\]/g" "/etc/php/$F_PHP_VERSION/fpm/pool.d/www.conf";
 
 systemctl restart php"${F_PHP_VERSION}"-fpm
 

--- a/scripts/php-setup.sh
+++ b/scripts/php-setup.sh
@@ -1,36 +1,61 @@
 #!/usr/bin/env bash
 
+# ./php-setup.sh --user=forge --version=8.3
+
 if [ "$USER" != 'root' ]; then
-    echo 'root privileges required. Please run this script as root.'
+    echo '[error] root privileges required. Please run this script as root.'
     exit 1
 fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-# TODO: Should be customizable.
-C_USERNAME="forge"
-C_PHP_VERSION="$1"
+F_USERNAME="forge"
+F_PHP_VERSION="$1"
+
+for OPTION in "$@"
+do
+    NAME="$(cut -d'=' -f1 <<<"$OPTION")"
+    VALUE="$(cut -d'=' -f2 <<<"$OPTION")"
+
+    if [ "$NAME" = '--user' ]; then
+        F_USERNAME="$VALUE"
+    elif [ "$NAME" = '--version' ]; then
+        F_PHP_VERSION="$VALUE"
+    else
+        echo "[error] Unrecognized option $NAME"
+    fi
+done
 
 add-apt-repository -y ppa:ondrej/php
 
 apt-get update
 
 apt-get install -y \
-    php"${C_PHP_VERSION}"-cli \
-    php"${C_PHP_VERSION}"-curl \
-    php"${C_PHP_VERSION}"-fpm \
-    php"${C_PHP_VERSION}"-gd \
-    php"${C_PHP_VERSION}"-imap \
-    php"${C_PHP_VERSION}"-mbstring \
-    php"${C_PHP_VERSION}"-mcrypt \
-    php"${C_PHP_VERSION}"-mysql \
-    php"${C_PHP_VERSION}"-pgsql \
-    php"${C_PHP_VERSION}"-sqlite3 \
-    php"${C_PHP_VERSION}"-xml \
-    php"${C_PHP_VERSION}"-zip
+    php"${F_PHP_VERSION}"-cli \
+    php"${F_PHP_VERSION}"-curl \
+    php"${F_PHP_VERSION}"-fpm \
+    php"${F_PHP_VERSION}"-gd \
+    php"${F_PHP_VERSION}"-imap \
+    php"${F_PHP_VERSION}"-mbstring \
+    php"${F_PHP_VERSION}"-mcrypt \
+    php"${F_PHP_VERSION}"-mysql \
+    php"${F_PHP_VERSION}"-pgsql \
+    php"${F_PHP_VERSION}"-sqlite3 \
+    php"${F_PHP_VERSION}"-xml \
+    php"${F_PHP_VERSION}"-zip
 
 php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer
 
-sed -i "s/www-data/${C_USERNAME}/g" "/etc/php/${C_PHP_VERSION}/fpm/pool.d/www.conf";
+sed -i "s/www-data/${F_USERNAME}/g" "/etc/php/${F_PHP_VERSION}/fpm/pool.d/www.conf";
+#sed -i "s/www-data/[www]/g" "/etc/php/[PHP ${F_PHP_VERSION}]/fpm/pool.d/www.conf";
 
-systemctl restart php"${C_PHP_VERSION}"-fpm
+systemctl restart php"${F_PHP_VERSION}"-fpm
+
+# Allows forge to run "sudo systemctl [reload|restart|status] php*-fpm" without password prompt.
+export FORGE_PHP_FPM_ACTIONS="
+forge ALL=(ALL) NOPASSWD: /usr/bin/systemctl reload php*-fpm
+forge ALL=(ALL) NOPASSWD: /usr/bin/systemctl restart php*-fpm
+forge ALL=(ALL) NOPASSWD: /usr/bin/systemctl status php*-fpm"
+if ! echo "${FORGE_PHP_FPM_ACTIONS}" | tee "/etc/sudoers.d/$F_USERNAME"; then
+    echo "[warning] Can not configure /etc/sudoers.d/$F_USERNAME file. You have to configure it by yourself."
+fi

--- a/scripts/provision-lemp.sh
+++ b/scripts/provision-lemp.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ "$USER" != 'root' ]; then
+    echo 'root privileges required. Please run this script as root.'
+    exit 1
+fi
+
+mkdir -p /root/provision/
+
+cd /root/provision/ || exit
+
+wget -O security-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/security-setup.sh
+wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/nginx-setup.sh
+wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/php-setup.sh
+wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/mysql-setup.sh
+
+bash security-setup.sh
+bash nginx-setup.sh
+bash php-setup.sh 8.3
+bash mysql-setup.sh
+
+rm -rf "*-setup.sh"

--- a/scripts/provision-lemp.sh
+++ b/scripts/provision-lemp.sh
@@ -27,6 +27,7 @@ do
         F_MYSQL_VERSION="$VALUE"
     else
         echo "[error] Unrecognized option $NAME"
+        exit 1
     fi
 done
 
@@ -41,7 +42,7 @@ wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like
 wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/php-setup.sh --quiet
 wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/mysql-setup.sh --quiet
 
-chmod +x "*-setup.sh"
+chmod +x *-setup.sh
 
 echo 'Run security-setup.sh'
 ./security-setup.sh --user="$F_USERNAME"

--- a/scripts/provision-lemp.sh
+++ b/scripts/provision-lemp.sh
@@ -37,10 +37,10 @@ cd /root/provision/ || exit
 
 echo 'Download scripts'
 
-wget -O security-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/security-setup.sh --quiet
-wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/nginx-setup.sh --quiet
-wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/php-setup.sh --quiet
-wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/mysql-setup.sh --quiet
+wget -O security-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/main/scripts/security-setup.sh --quiet
+wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/main/scripts/nginx-setup.sh --quiet
+wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/main/scripts/php-setup.sh --quiet
+wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/main/scripts/mysql-setup.sh --quiet
 
 chmod +x *-setup.sh
 

--- a/scripts/provision-lemp.sh
+++ b/scripts/provision-lemp.sh
@@ -1,22 +1,58 @@
 #!/usr/bin/env bash
 
+# ./security-setup.sh --user=forge --php=8.3 --mysql=8.0
+
 if [ "$USER" != 'root' ]; then
-    echo 'root privileges required. Please run this script as root.'
+    echo '[error] root privileges required. Please run this script as root.'
     exit 1
 fi
+
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
+F_USERNAME=forge
+F_PHP_VERSION=8.3
+F_MYSQL_VERSION=8.0
+
+for OPTION in "$@"
+do
+    NAME="$(cut -d'=' -f1 <<<"$OPTION")"
+    VALUE="$(cut -d'=' -f2 <<<"$OPTION")"
+
+    if [ "$NAME" = '--user' ]; then
+        F_USERNAME="$VALUE"
+    elif [ "$NAME" = '--php' ]; then
+        F_PHP_VERSION="$VALUE"
+    elif [ "$NAME" = '--mysql' ]; then
+        F_MYSQL_VERSION="$VALUE"
+    else
+        echo "[error] Unrecognized option $NAME"
+    fi
+done
 
 mkdir -p /root/provision/
 
 cd /root/provision/ || exit
 
-wget -O security-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/security-setup.sh
-wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/nginx-setup.sh
-wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/php-setup.sh
-wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/mysql-setup.sh
+echo 'Download scripts'
 
-bash security-setup.sh
-bash nginx-setup.sh
-bash php-setup.sh 8.3
-bash mysql-setup.sh
+wget -O security-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/security-setup.sh --quiet
+wget -O nginx-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/nginx-setup.sh --quiet
+wget -O php-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/php-setup.sh --quiet
+wget -O mysql-setup.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/mysql-setup.sh --quiet
+
+chmod +x "*-setup.sh"
+
+echo 'Run security-setup.sh'
+./security-setup.sh --user="$F_USERNAME"
+
+echo 'Run nginx-setup.sh'
+./nginx-setup.sh --user="$F_USERNAME"
+
+echo 'Run php-setup.sh'
+./php-setup.sh --user="$F_USERNAME" --version="$F_PHP_VERSION"
+
+echo 'Run mysql-setup.sh'
+./mysql-setup.sh --version="$F_MYSQL_VERSION"
 
 rm -rf "*-setup.sh"

--- a/scripts/security-setup.sh
+++ b/scripts/security-setup.sh
@@ -25,6 +25,7 @@ do
         F_USERNAME="$VALUE"
     else
         echo "[error] Unrecognized option $NAME"
+        exit 1
     fi
 done
 

--- a/scripts/security-setup.sh
+++ b/scripts/security-setup.sh
@@ -45,6 +45,12 @@ touch /home/forge/.ssh/authorized_keys
 
 chmod 660 /home/forge/.ssh/authorized_keys
 
+# Because DigitalOcean or Hetzner Cloud allows to SSH using root, so I just copy these keys.
+# Thus, right after provision process, I can SSH using forge without adding additional SSH keys.
+if [ -f /root/.ssh/authorized_keys ]; then
+    cat /root/.ssh/authorized_keys > /home/forge/.ssh/authorized_keys
+fi
+
 chown -R forge:forge /home/forge/.ssh
 
 systemctl restart ssh

--- a/scripts/security-setup.sh
+++ b/scripts/security-setup.sh
@@ -1,32 +1,48 @@
 #!/usr/bin/env bash
 
+# ./security-setup.sh --user=forge
+
 if [ "$USER" != 'root' ]; then
-    echo 'root privileges required. Please run this script as root.'
+    echo '[error] root privileges required. Please run this script as root.'
     exit 1
 fi
 
 export DEBIAN_FRONTEND=noninteractive
 export NEEDRESTART_MODE=a
 
-# TODO: Should be customizable.
-C_USERNAME="forge"
-C_PASSWORD="secret"
+# TODO: Should it be customizable via --password=<password> or prompt?
+F_PASSWORD="secret"
 
-if id "forge" >/dev/null 2>&1; then
-    echo "The user \"forge\" already exists."
+# The default username is "forge"
+F_USERNAME="forge"
+
+for OPTION in "$@"
+do
+    NAME="$(cut -d'=' -f1 <<<"$OPTION")"
+    VALUE="$(cut -d'=' -f2 <<<"$OPTION")"
+
+    if [ "$NAME" = '--user' ]; then
+        F_USERNAME="$VALUE"
+    else
+        echo "[error] Unrecognized option $NAME"
+    fi
+done
+
+if id "$F_USERNAME" >/dev/null 2>&1; then
+    echo "[warning] The user \"$F_USERNAME\" already exists."
 else
-    adduser --disabled-password --gecos "The root alternative" "${C_USERNAME}"
+    adduser --disabled-password --gecos "Using $F_USERNAME instead of root" "${F_USERNAME}"
 fi
 
-usermod --password $(echo "${C_PASSWORD}" | openssl passwd -1 -stdin) "${C_USERNAME}"
+usermod --password $(echo "${F_PASSWORD}" | openssl passwd -1 -stdin) "${F_USERNAME}"
 
-usermod -aG sudo forge
+usermod -aG sudo "$F_USERNAME"
 
 rm -rf /etc/ssh/sshd_config.d/*
 
-touch /etc/ssh/sshd_config.d/forge-init.conf
+touch "/etc/ssh/sshd_config.d/$F_USERNAME-init.conf"
 
-chmod 600 /etc/ssh/sshd_config.d/forge-init.conf
+chmod 600 "/etc/ssh/sshd_config.d/$F_USERNAME-init.conf"
 
 export SSHD_CONFIG="
 PermitRootLogin no
@@ -34,24 +50,24 @@ PasswordAuthentication no
 PermitEmptyPasswords no
 PubkeyAuthentication yes
 
-AllowGroups forge"
-if ! echo "${SSHD_CONFIG}" | tee /etc/ssh/sshd_config.d/forge-init.conf; then
-    echo "Can NOT configure SSH!" && exit 1
+AllowGroups $F_USERNAME"
+if ! echo "${SSHD_CONFIG}" | tee "/etc/ssh/sshd_config.d/$F_USERNAME-init.conf"; then
+    echo "[error] Can NOT configure SSH!" && exit 1
 fi
 
-mkdir -p /home/forge/.ssh
+mkdir -p "/home/$F_USERNAME/.ssh"
 
-touch /home/forge/.ssh/authorized_keys
+touch "/home/$F_USERNAME/.ssh/authorized_keys"
 
-chmod 660 /home/forge/.ssh/authorized_keys
+chmod 660 "/home/$F_USERNAME/.ssh/authorized_keys"
 
 # Because DigitalOcean or Hetzner Cloud allows to SSH using root, so I just copy these keys.
 # Thus, right after provision process, I can SSH using forge without adding additional SSH keys.
 if [ -f /root/.ssh/authorized_keys ]; then
-    cat /root/.ssh/authorized_keys > /home/forge/.ssh/authorized_keys
+    cat /root/.ssh/authorized_keys > "/home/$F_USERNAME/.ssh/authorized_keys"
 fi
 
-chown -R forge:forge /home/forge/.ssh
+chown -R "$F_USERNAME":"$F_USERNAME" "/home/$F_USERNAME/.ssh"
 
 systemctl restart ssh
 


### PR DESCRIPTION
Add a simple script to quickly provision a LEMP server.

```bash
wget -O provision-lemp.sh https://raw.githubusercontent.com/confetticode/forge-like-setup/provision-lemp/scripts/provision-lemp.sh --quiet

chmod +x provision-lemp.sh

./provision-lemp.sh --user=forge --php=8.3 --mysql=8.0
```

There are 2 more things that need to be done:
- Validate supported OS. E.g: Ubuntu 22.04 or 24.04
- Validate valid option values: E.g: ./provision-lemp.sh --php=8.1 currently fails.